### PR TITLE
Increase output precision of file1d

### DIFF
--- a/gnuplot-iostream.h
+++ b/gnuplot-iostream.h
@@ -1711,6 +1711,7 @@ public:
 	std::string file(const T &arg, std::string filename, OrganizationMode) {
 		if(filename.empty()) filename = make_tmpfile();
 		std::fstream tmp_stream(filename.c_str(), std::fstream::out);
+		tmp_stream << std::setprecision(16);
 		top_level_array_sender(tmp_stream, arg, OrganizationMode(), ModeText());
 		tmp_stream.close();
 

--- a/gnuplot-iostream.h
+++ b/gnuplot-iostream.h
@@ -1599,7 +1599,7 @@ public:
 		tmp_files(),
 		debug_messages(false)
 	{
-		*this << std::scientific << std::setprecision(18);  // refer <iomanip>
+		*this << std::scientific << std::setprecision(17);  // refer <iomanip>
 	}
 
 	explicit Gnuplot(FILE *_fh) :
@@ -1616,7 +1616,7 @@ public:
 		tmp_files(),
 		debug_messages(false)
 	{
-		*this << std::scientific << std::setprecision(18);  // refer <iomanip>
+		*this << std::scientific << std::setprecision(17);  // refer <iomanip>
 	}
 
 private:
@@ -1711,7 +1711,7 @@ public:
 	std::string file(const T &arg, std::string filename, OrganizationMode) {
 		if(filename.empty()) filename = make_tmpfile();
 		std::fstream tmp_stream(filename.c_str(), std::fstream::out);
-		tmp_stream << std::setprecision(16);
+		tmp_stream << std::scientific << std::setprecision(17);
 		top_level_array_sender(tmp_stream, arg, OrganizationMode(), ModeText());
 		tmp_stream.close();
 


### PR DESCRIPTION
I noticed that sending floating point values through file1d leads to data files where the numbers have 6 digits or less.
I send raw data through file1d and then plot differences where the raw values are roughly in the range [1000:6000] and the differences are in the range [0:1] which leads to loss of precision. I did a quick hack to fix it so I can continue using it the way I do, it would probably be cleaner to somehow let the user choose the precision via an optional argument.