### PR TITLE
Added support for std::valarray

### DIFF
--- a/gnuplot-iostream.h
+++ b/gnuplot-iostream.h
@@ -69,6 +69,7 @@ THE SOFTWARE.
 #include <cmath>
 #include <tuple>
 #include <type_traits>
+#include <valarray>
 
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -854,6 +855,21 @@ public:
 
     static range_type get_range(const T (&arg)[N]) {
         return range_type(arg, arg+N);
+    }
+};
+
+// }}}2
+
+// {{{2 std::valarray support
+
+template <typename T>
+class ArrayTraits<std::valarray<T>> : public ArrayTraitsDefaults<T> {
+public:
+    // Iterator type for valarray is implementation dependent
+    typedef IteratorRange<decltype(std::begin(std::declval<const std::valarray<T>>())), T> range_type;
+
+    static range_type get_range(const std::valarray<T> &arg) {
+        return range_type(std::begin(arg), std::end(arg));
     }
 };
 


### PR DESCRIPTION
Using `Gnuplot::send...()` with `std::valarray` causes an error. This is because `std::valarray` has no `begin()`/`end()` member functions (the STL provides separate functions for this), so valarrays are not recognized as STL containers by `ArrayTraits`.

This update fixes this by providing a template specialization of `ArrayTraits` so that it can recognize `std::valarray`s.